### PR TITLE
Conversion of API response's CellFormat properties failed for

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ Sphinx-PyPI-upload3
 twine
 nose
 oauth2client
+pandas

--- a/test.py
+++ b/test.py
@@ -108,6 +108,10 @@ class WorksheetTest(GspreadTest):
         f = numberFormat('TEXT', '###0')
         f = border('DOTTED', color(0.2, 0.2, 0.2))
 
+    def test_bottom_attribute(self):
+        f = padding(bottom=1.1)
+        f = borders(bottom=border('SOLID'))
+
     def test_format_range(self):
         rows = [["", "", "", ""],
                 ["", "", "", ""],
@@ -134,6 +138,32 @@ class WorksheetTest(GspreadTest):
         self.assertEqual(ue_fmt.textFormat.italic, True)
         eff_fmt = get_effective_format(self.sheet, 'A1')
         self.assertEqual(eff_fmt.textFormat.italic, True)
+
+    def test_bottom_formatting(self):
+        rows = [["", "", "", ""],
+                ["", "", "", ""],
+                ["A1", "B1", "", "D1"],
+                [1, "b2", 1.45, ""],
+                ["", "", "", ""],
+                ["A4", 0.4, "", 4]]
+
+        def_fmt = get_default_format(self.spreadsheet)
+        cell_list = self.sheet.range('A1:D6')
+        for cell, value in zip(cell_list, itertools.chain(*rows)):
+            cell.value = value
+        self.sheet.update_cells(cell_list)
+        fmt = cellFormat(textFormat=textFormat(bold=True))
+        format_cell_ranges(self.sheet, [('A1:B6', fmt), ('C1:D6', fmt)])
+
+        orig_fmt = get_user_entered_format(self.sheet, 'A1')
+        new_fmt = cellFormat(borders=borders(bottom=border('SOLID')), padding=padding(bottom=3))
+        format_cell_range(self.sheet, 'A1:A1', new_fmt)
+        ue_fmt = get_user_entered_format(self.sheet, 'A1')
+        self.assertEqual(new_fmt.borders.bottom.style, ue_fmt.borders.bottom.style)
+        self.assertEqual(new_fmt.padding.bottom, ue_fmt.padding.bottom)
+        eff_fmt = get_effective_format(self.sheet, 'A1')
+        self.assertEqual(new_fmt.borders.bottom.style, eff_fmt.borders.bottom.style)
+        self.assertEqual(new_fmt.padding.bottom, eff_fmt.padding.bottom)
 
     def test_frozen_rows_cols(self):
         set_frozen(self.sheet, rows=1, cols=1)


### PR DESCRIPTION
certain nested format components such as borders.bottom. Added test
coverage to trigger bug, and code changes to solve the bug. Also
added support of deprecated width= attribute for Border format
component.

Fixes #4.