### PR TITLE
Color model import and export as hex color

### DIFF
--- a/gspread_formatting/models.py
+++ b/gspread_formatting/models.py
@@ -195,13 +195,25 @@ class Color(CellFormatComponent):
 
     @classmethod
     def fromHex(cls,hexcolor):
+        # Check Hex String
+        if not hexcolor.startswith('#'):
+            raise ValueError(f'Color string given: {hexcolor}: Hex color strings must start with #')
+        hexlen = len(hexcolor)
+        if hexlen != 7 and hexlen != 9:
+            raise ValueError(f'Color string given: {hexcolor}: Hex string must be of the form: "#RRGGBB" or "#RRGGBBAA')
+        # Remainder of string should be parsable as hex
+        try:
+            if int(hexcolor[1:],16):
+                pass
+        except Exception as e:
+            raise ValueError(f'Color string given: {hexcolor}: Bad color string entered')
         # Convert Hex range 0-255 to 0-1.0
         RR = int(hexcolor[1:3],16) / 255
         GG = int(hexcolor[3:5],16) / 255
         BB = int(hexcolor[5:7],16) / 255
         # Slices wont causes IndexErrors
         A = hexcolor[7:9]
-        if A is '':
+        if not A:
             AA = None
         else:
             AA = int(A,16) / 255
@@ -212,7 +224,8 @@ class Color(CellFormatComponent):
         GG = format(int((self.green if self.green else 0) * 255), '02x')
         BB = format(int((self.blue if self.blue else 0) * 255), '02x')
         AA = format(int((self.alpha if self.alpha else 0) * 255), '02x')
-        if self.alpha:
+
+        if self.alpha != None:
             hexformat = f'#{RR}{GG}{BB}{AA}'
         else:
             hexformat = f'#{RR}{GG}{BB}'

--- a/gspread_formatting/models.py
+++ b/gspread_formatting/models.py
@@ -189,19 +189,29 @@ class ColorStyle(CellFormatComponent):
 class Color(CellFormatComponent):
     _FIELDS = ('red', 'green', 'blue', 'alpha')
 
-    def __init__(self, red=None, green=None, blue=None, alpha=None):
+    def __init__(self, red=None, green=None, blue=None, alpha=None, hexcolor=None):
         self.red = red
         self.green = green
         self.blue = blue
         self.alpha = alpha
+        if hexcolor:
+            self.fromHex(hexcolor)
 
-    def toHex():
+    def toHex(self):
+        # Dont worry about alpha channel yet
         # This would simpler if the default was 0 instead of None
-        RR = format(floor((self.red if self.red else 0) * 255), 'x')
-        GG = format(floor((self.green if self.green else 0) * 255), 'x')
-        BB = format(floor((self.blue if self.blue else 0) * 255), 'x')
+        RR = format(floor((self.red if self.red else 0) * 255), '02x')
+        GG = format(floor((self.green if self.green else 0) * 255), '02x')
+        BB = format(floor((self.blue if self.blue else 0) * 255), '02x')
         hexformat = f'#{RR}{GG}{BB}'
         return hexformat
+
+    def fromHex(self,hexcolor):
+        # Dont worry about alpha channel yet
+        self.red = int(hexcolor[1:3],16) / 255
+        self.green = int(hexcolor[3:5],16) / 255
+        self.blue = int(hexcolor[5:7],16) / 255
+
 
 class Border(CellFormatComponent):
     _FIELDS = ('style', 'color', 'colorStyle')

--- a/gspread_formatting/models.py
+++ b/gspread_formatting/models.py
@@ -2,8 +2,6 @@
 
 from .util import _props_to_component, _extract_props, _extract_fieldrefs, \
     _parse_string_enum, _underlower, _range_to_gridrange_object
-
-from math import floor
                   
 class FormattingComponent(object):
     _FIELDS = ()
@@ -189,29 +187,36 @@ class ColorStyle(CellFormatComponent):
 class Color(CellFormatComponent):
     _FIELDS = ('red', 'green', 'blue', 'alpha')
 
-    def __init__(self, red=None, green=None, blue=None, alpha=None, hexcolor=None):
+    def __init__(self, red=None, green=None, blue=None, alpha=None):
         self.red = red
         self.green = green
         self.blue = blue
         self.alpha = alpha
-        if hexcolor:
-            self.fromHex(hexcolor)
+
+    @classmethod
+    def fromHex(cls,hexcolor):
+        # Convert Hex range 0-255 to 0-1.0
+        RR = int(hexcolor[1:3],16) / 255
+        GG = int(hexcolor[3:5],16) / 255
+        BB = int(hexcolor[5:7],16) / 255
+        # Slices wont causes IndexErrors
+        A = hexcolor[7:9]
+        if A is '':
+            AA = None
+        else:
+            AA = int(A,16) / 255
+        return cls(RR,GG,BB,AA)
 
     def toHex(self):
-        # Dont worry about alpha channel yet
-        # This would simpler if the default was 0 instead of None
-        RR = format(floor((self.red if self.red else 0) * 255), '02x')
-        GG = format(floor((self.green if self.green else 0) * 255), '02x')
-        BB = format(floor((self.blue if self.blue else 0) * 255), '02x')
-        hexformat = f'#{RR}{GG}{BB}'
+        RR = format(int((self.red if self.red else 0) * 255), '02x')
+        GG = format(int((self.green if self.green else 0) * 255), '02x')
+        BB = format(int((self.blue if self.blue else 0) * 255), '02x')
+        AA = format(int((self.alpha if self.alpha else 0) * 255), '02x')
+        if self.alpha:
+            hexformat = f'#{RR}{GG}{BB}{AA}'
+        else:
+            hexformat = f'#{RR}{GG}{BB}'
         return hexformat
-
-    def fromHex(self,hexcolor):
-        # Dont worry about alpha channel yet
-        self.red = int(hexcolor[1:3],16) / 255
-        self.green = int(hexcolor[3:5],16) / 255
-        self.blue = int(hexcolor[5:7],16) / 255
-
 
 class Border(CellFormatComponent):
     _FIELDS = ('style', 'color', 'colorStyle')

--- a/gspread_formatting/models.py
+++ b/gspread_formatting/models.py
@@ -2,6 +2,8 @@
 
 from .util import _props_to_component, _extract_props, _extract_fieldrefs, \
     _parse_string_enum, _underlower, _range_to_gridrange_object
+
+from math import floor
                   
 class FormattingComponent(object):
     _FIELDS = ()
@@ -192,6 +194,14 @@ class Color(CellFormatComponent):
         self.green = green
         self.blue = blue
         self.alpha = alpha
+
+    def toHex():
+        # This would simpler if the default was 0 instead of None
+        RR = format(floor((self.red if self.red else 0) * 255), 'x')
+        GG = format(floor((self.green if self.green else 0) * 255), 'x')
+        BB = format(floor((self.blue if self.blue else 0) * 255), 'x')
+        hexformat = f'#{RR}{GG}{BB}'
+        return hexformat
 
 class Border(CellFormatComponent):
     _FIELDS = ('style', 'color', 'colorStyle')

--- a/test.py
+++ b/test.py
@@ -465,5 +465,26 @@ class WorksheetTest(GspreadTest):
         for col in col_md[0:1]:
             self.assertEqual(187, col['pixelSize'])
 
+class ColorTest(unittest.TestCase):
+
+    SAMPLE_HEXSTRINGS_NOALPHA = ['#230ac7','#9ec08b','#037778','#134d70','#f1f974','#0997b6','#42da14','#be5ee8']
+    SAMPLE_HEXSTRINGS_ALPHA = ['#b7d90600','#0a29f321','#33db6a48','#4134a467','#7d172388','#58fe5fa1','#2ea14ecc','#c18de9f8']
+    SAMPLE_HEXSTRING_CAPS = ['#DDEEFF','#EEFFAABB','#1A2B3C4E','#A1F2B3']
+    # [NO_POUND_SIGN, NO_POUND_SIGN_ALPHA, INVALID_HEX_CHAR, INVALID_HEX_CHAR_ALPHA, SPECIAL_INVALID_CHAR, TOO_FEW_CHARS, TOO_MANY_CHARS]
+    SAMPLE_HEXSTRINGS_BAD = ['230ac7','9ec08b9b','#Adbeye','#1122ccgg','#11$100FF', '#11678','#867530910']
+
+    def test_color_roundtrip(self):
+        for hexstring in self.SAMPLE_HEXSTRINGS_NOALPHA:
+            self.assertEqual(hexstring, Color.fromHex(hexstring).toHex())
+        for hexstring in self.SAMPLE_HEXSTRINGS_ALPHA:
+            self.assertEqual(hexstring, Color.fromHex(hexstring).toHex())
+        for hexstring in self.SAMPLE_HEXSTRING_CAPS:
+            # Check equality with lowercase version of string
+            self.assertEqual(hexstring.lower(), Color.fromHex(hexstring).toHex())
+
+    def test_color_malformed(self):
+        for hexstring in self.SAMPLE_HEXSTRINGS_BAD:
+            with self.assertRaises(ValueError):
+                Color.fromHex(hexstring)
 
 


### PR DESCRIPTION
This PR adds two functions to the Color model, toHex and fromHex, for making this model more interoperable with other libraries and projects. The 0-1 color scale the google sheets api uses is not standard, and it is tedious to convert back and forth.

I am trying to use the webcolors python project with gspread-formatting and these functions will make converting to/from color names much easier.

Please let know if I can do anything to improve the PR, I haven't worked on that many public github projects before.