### PR TITLE
TextFormatRun.format now optional, has empty default

### DIFF
--- a/gspread_formatting/models.py
+++ b/gspread_formatting/models.py
@@ -302,7 +302,7 @@ class TextFormat(CellFormatComponent):
 class TextFormatRun(FormattingComponent):
     _FIELDS = {'format': 'textFormat', 'startIndex': None}
 
-    def __init__(self, format, startIndex=0):
+    def __init__(self, format=None, startIndex=0):
         self.startIndex = startIndex
         self.format = format if format is not None else TextFormat()
 


### PR DESCRIPTION
Fixes #59.

TextFormatRun was alone amongst the model classes in having a non-optional parameter, which was `format`. Changes to `format=None` and substitutes a fresh TextFormat() for None when assigning parameter to the attribute. This allows for Sheets API responses that can return an empty TextFormatRun element in the array of TextFormatRun objects.